### PR TITLE
Fix exception when extra_args can't be sorted by value

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -44,7 +44,9 @@ class DjangoConnectionField(ConnectionField):
 
     @property
     def args(self):
-        return to_arguments(self._base_args or OrderedDict(), self.node_type.get_connection_parameters())
+        args = OrderedDict(self._base_args)
+        args.update(self.node_type.get_connection_parameters())
+        return to_arguments(args)
 
     @args.setter
     def args(self, args):


### PR DESCRIPTION
The `to_arguments` function tries to sort extra_args by their values instead of their keys. I'm really not sure why. In any case, this caused issues when passing normal graphene Input fields in `get_connection_parameters`.